### PR TITLE
chore: skip major version updates for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       prefix: "chore: "
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: devcontainers
     directory: /


### PR DESCRIPTION
This PR updates the Dependabot configuration to skip major version updates for npm packages by adding the appropriate ignore rule. GitHub Actions and other ecosystems remain unimpacted.