### PR TITLE
feat: automate dist rebuild for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-rebuild-dist.yml
+++ b/.github/workflows/dependabot-rebuild-dist.yml
@@ -1,0 +1,48 @@
+name: Dependabot dist rebuild
+
+# pull_request_target runs with write GITHUB_TOKEN even for Dependabot PRs,
+# unlike pull_request which gets a read-only token.
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: write
+
+env:
+  GIT_USER_NAME: github-actions[bot]
+  GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+jobs:
+  rebuild-dist:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild the dist/ directory
+        run: npm run package
+
+      - name: Commit dist changes
+        run: |
+          git config user.name "${{ env.GIT_USER_NAME }}"
+          git config user.email "${{ env.GIT_USER_EMAIL }}"
+          git add dist/
+          if git diff --staged --quiet; then
+            echo "dist/ is already up to date"
+          else
+            git commit -m "chore: rebuild dist for dependency update"
+            git push
+          fi


### PR DESCRIPTION
## Summary

- Adds a `dependabot-rebuild-dist` workflow triggered on `pull_request_target` for Dependabot PRs
- Rebuilds and commits `dist/` so the `check-dist` workflow passes without manual intervention
- Uses `pull_request_target` to get a write-capable `GITHUB_TOKEN` (Dependabot PRs receive a read-only token on `pull_request`)

Closes #481