### PR TITLE
fix: retrigger CI workflows after Dependabot dist rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
 
 jobs:
   ci: # Code quality: Linting, Formatting, and Unit Tests

--- a/.github/workflows/dependabot-rebuild-dist.yml
+++ b/.github/workflows/dependabot-rebuild-dist.yml
@@ -2,12 +2,15 @@ name: Dependabot dist rebuild
 
 # pull_request_target runs with write GITHUB_TOKEN even for Dependabot PRs,
 # unlike pull_request which gets a read-only token.
+# After pushing, the CI workflows are re-triggered via workflow_dispatch because
+# commits pushed by GITHUB_TOKEN do not automatically trigger new workflow runs.
 on:
   pull_request_target:
     branches: [main]
 
 permissions:
   contents: write
+  actions: write
 
 env:
   GIT_USER_NAME: github-actions[bot]
@@ -36,13 +39,27 @@ jobs:
         run: npm run package
 
       - name: Commit dist changes
+        id: commit
         run: |
           git config user.name "${{ env.GIT_USER_NAME }}"
           git config user.email "${{ env.GIT_USER_EMAIL }}"
           git add dist/
           if git diff --staged --quiet; then
             echo "dist/ is already up to date"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: rebuild dist for dependency update"
             git push
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Re-trigger CI workflows
+        if: steps.commit.outputs.pushed == 'true'
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh workflow run check-dist.yml --ref "$BRANCH"
+          gh workflow run integration-tests.yml --ref "$BRANCH"
+          gh workflow run codeql-analysis.yml --ref "$BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
 
 jobs:
   test: # make sure the action works on a clean machine without building


### PR DESCRIPTION
## Summary

- Adds a re-trigger step to `dependabot-rebuild-dist` that dispatches CI workflows after committing a dist rebuild, since commits pushed by `GITHUB_TOKEN` do not automatically trigger new workflow runs (`workflow_dispatch` is explicitly exempt from this restriction per GitHub docs)
- Adds `workflow_dispatch` trigger to `ci.yml` and `integration-tests.yml` to support this (it was already present on `check-dist.yml` and `codeql-analysis.yml`)

Closes #481